### PR TITLE
ci: add deployment analytics github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,14 @@
 name: Release
 concurrency: sdk-release
+
 on:
     release:
         types:
             - published
+
+env:
+    BIGQUERY_TABLE: jarvis-dev-268314.deployment_analytics.deployment_events
+
 jobs:
   release:
     name: Release SDK to pypi repository
@@ -16,9 +21,9 @@ jobs:
         with:
           python-version: "3.8"
           cache: "pipenv"
-      - name: "Install"
+      - name: Install
         run: pipenv install
-      - name: "Build"
+      - name: Build
         run: |
           pipenv run python setup.py sdist bdist_wheel
       - name: Publish a Python package to PyPI
@@ -44,3 +49,17 @@ jobs:
           APP_TAG: "jarvis-sdk-python"
         run: |
           CU_tags="$APP_TAG,$VERSION" cu-cli create -d "Release of $APP_NAME available here: https://pypi.org/project/$APP_TAG/$VERSION/" "$APP_NAME - release $VERSION"
+
+      # Publish deployment metadata
+      - name: Authenticate to Google Cloud
+        if: ${{ always() }}
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SECRET_KEY }}
+      - name: Publish Deployment Metadata
+        if: ${{ always() }}
+        uses: indykite/metadata-publisher@v0
+        with:
+          version: ${{ env.VERSION }}
+          status: ${{ job.status }}
+          bigquery_table: ${{ env.BIGQUERY_TABLE }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project serves as a Software Development Kit for developers of Indykite applications.
 
+[![codecov](https://codecov.io/gh/indykite/jarvis-sdk-python/branch/master/graph/badge.svg?token=8u4yvyi5PN)](https://codecov.io/gh/indykite/jarvis-sdk-python)
+
 ## Requirements
 
 * Python 3.8


### PR DESCRIPTION
# Checklist

- [x] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## Description of change

Adds github action for saving deployment metadata to bigquery 
